### PR TITLE
wrapped 'my annotation' code with a flag in config

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -243,3 +243,6 @@ environments:
     production:
         dataSource:
             dbCreate: none
+
+myannotation:
+    enabled: false

--- a/grails-app/controllers/au/org/ala/alerts/UrlMappings.groovy
+++ b/grails-app/controllers/au/org/ala/alerts/UrlMappings.groovy
@@ -23,8 +23,6 @@ class UrlMappings {
         "/admin/user/deleteMyAlert/$id?"(controller: 'notification', action: 'deleteMyAlert')
         "/admin/user/deleteMyAlertWR/$id?"(controller: 'notification', action: 'deleteMyAlertWR')
         "/admin/user/addMyAlert/$id?"(controller: 'notification', action: 'addMyAlert')
-        "/admin/user/addMyAnnotation/"(controller: 'notification', action: 'addMyAnnotation')
-        "/admin/user/deleteMyAnnotation/"(controller: 'notification', action: 'deleteMyAnnotation')
         "/admin/user"(controller: 'admin', action: 'findUser')
         "/admin/debug/all"(controller: 'admin', action: 'debugAllAlerts')
 
@@ -47,8 +45,6 @@ class UrlMappings {
         "/api/alerts/user/createAlerts"(controller: 'webservice', action: [POST: 'createUserAlerts'])
 
         "/api/alerts/user/$userId"(controller: 'webservice', action: [GET: 'getUserAlertsWS'])
-        "/api/alerts/user/$userId/addMyAnnotationAlert"(controller: 'webservice', action: [POST: 'addMyAnnotationAlertWS'])
-        "/api/alerts/user/$userId/deleteMyAnnotationAlert"(controller: 'webservice', action: [POST: 'deleteMyAnnotationAlertWS'])
 
         "/robots.txt"(view:'/notFound')
         "400"(view:'/error')

--- a/grails-app/init/au/org/ala/alerts/BootStrap.groovy
+++ b/grails-app/init/au/org/ala/alerts/BootStrap.groovy
@@ -6,9 +6,21 @@ class BootStrap {
     def grailsApplication
     def messageSource
     def siteLocale
+    def grailsUrlMappingsHolder
 
     def init = { servletContext ->
         log.info("Running bootstrap queries.")
+
+        // if my annotation feature turned on, add url mapping to handle add/remove alert requests
+        if (grailsApplication.config.myannotation.enabled) {
+            grailsUrlMappingsHolder.addMappings({
+                "/admin/user/addMyAnnotation/"(controller: 'notification', action: 'addMyAnnotation')
+                "/admin/user/deleteMyAnnotation/"(controller: 'notification', action: 'deleteMyAnnotation')
+
+                "/api/alerts/user/$userId/addMyAnnotationAlert"(controller: 'webservice', action: [POST: 'addMyAnnotationAlertWS'])
+                "/api/alerts/user/$userId/deleteMyAnnotationAlert"(controller: 'webservice', action: [POST: 'deleteMyAnnotationAlertWS'])
+            })
+        }
 
         messageSource.setBasenames(
                 "file:///var/opt/atlas/i18n/alerts/messages",

--- a/grails-app/init/au/org/ala/alerts/BootStrap.groovy
+++ b/grails-app/init/au/org/ala/alerts/BootStrap.groovy
@@ -12,7 +12,7 @@ class BootStrap {
         log.info("Running bootstrap queries.")
 
         // if my annotation feature turned on, add url mapping to handle add/remove alert requests
-        if (grailsApplication.config.myannotation.enabled) {
+        if (grailsApplication.config.getProperty('myannotation.enabled', Boolean, false)) {
             grailsUrlMappingsHolder.addMappings({
                 "/admin/user/addMyAnnotation/"(controller: 'notification', action: 'addMyAnnotation')
                 "/admin/user/deleteMyAnnotation/"(controller: 'notification', action: 'deleteMyAnnotation')

--- a/grails-app/services/au/org/ala/alerts/UserService.groovy
+++ b/grails-app/services/au/org/ala/alerts/UserService.groovy
@@ -50,7 +50,7 @@ class UserService {
                           frequencies    : Frequency.listOrderByPeriodInSeconds(),
                           user           : user]
 
-        if (grailsApplication.config.myannotation.enabled) {
+        if (grailsApplication.config.getProperty('myannotation.enabled', Boolean, false)) {
             def myannotationName = messageSource.getMessage("query.myannotations.title", null, siteLocale)
             def myannotation = userConfig.enabledQueries.findAll { it.name == myannotationName }
             userConfig.enabledQueries.removeAll { it.name == myannotationName }

--- a/grails-app/views/notification/myAlerts.gsp
+++ b/grails-app/views/notification/myAlerts.gsp
@@ -65,23 +65,26 @@
                             </tr>
                         </g:each>
 
-                        <g:set var="myannotationChecked" value="${myannotation.size() != 0}" />
-                        <tr>
-                            <td class="queryDescription">
-                                <h3>My Annotations</h3>
-                                Notify me when records I have flagged are updated.
-                            </td>
-                            <td class="queryActions">
-                                <div class="switch" data-on="danger" >
-                                    <g:if test="${myannotationChecked}">
-                                        <input data-type='myannotation' class="query-cb" name="field2"  type="checkbox" checked/>
-                                    </g:if>
-                                    <g:else>
-                                        <input data-type='myannotation' class="query-cb" name="field2"  type="checkbox" />
-                                    </g:else>
-                                </div>
-                            </td>
-                        </tr>
+                        %{--test if my annotation feature is turned on--}%
+                        <g:if test="${myannotation != null}">
+                            <g:set var="myannotationChecked" value="${myannotation.size() != 0}" />
+                            <tr>
+                                <td class="queryDescription">
+                                    <h3>My Annotations</h3>
+                                    Notify me when records I have flagged are updated.
+                                </td>
+                                <td class="queryActions">
+                                    <div class="switch" data-on="danger" >
+                                        <g:if test="${myannotationChecked}">
+                                            <input data-type='myannotation' class="query-cb" name="field2"  type="checkbox" checked/>
+                                        </g:if>
+                                        <g:else>
+                                            <input data-type='myannotation' class="query-cb" name="field2"  type="checkbox" />
+                                        </g:else>
+                                    </div>
+                                </td>
+                            </tr>
+                        </g:if>
 
                         </tbody>
                     </table>


### PR DESCRIPTION
1. a flag (value = false) is set in application.yml so it can be overwritten by an external config file
2. when flag == true, 4 more url mapping are added so can process add/remove my annotation alerts API call
3. when flag == false, myannotation won't be added to userConfig which is passed to `myAlerts.gsp` so no 'my annotation' switch available