### PR TITLE
Fix for "View this null record" link text in records email

### DIFF
--- a/grails-app/views/email/biocache.gsp
+++ b/grails-app/views/email/biocache.gsp
@@ -53,7 +53,12 @@
           </g:else>
           </td>
          <td class="linkCell" nowrap="nowrap">
+         <g:if test="${oc.scientificName}">
            <a href="${query.baseUrlForUI}/occurrences/${oc.uuid}"><g:message code="biocache.view.this.record" args="[oc.scientificName]" /></a>
+         </g:if>
+         <g:else>
+           <a href="${query.baseUrlForUI}/occurrences/${oc.uuid}"><g:message code="biocache.record.details" /></a>
+         </g:else>
          </td>
       </tr>
       </tbody>

--- a/grails-app/views/email/biocache.gsp
+++ b/grails-app/views/email/biocache.gsp
@@ -53,7 +53,7 @@
           </g:else>
           </td>
          <td class="linkCell" nowrap="nowrap">
-         <g:if test="${oc.scientificName}">
+         <g:if test="${oc.scientificName != null}">
            <a href="${query.baseUrlForUI}/occurrences/${oc.uuid}"><g:message code="biocache.view.this.record" args="[oc.scientificName]" /></a>
          </g:if>
          <g:else>


### PR DESCRIPTION
Fix for "View this null record" link text in records email - related to #41