### PR TITLE
correctly handle unsubscribe myannotation with token

### DIFF
--- a/grails-app/controllers/au/org/ala/alerts/UnsubscribeController.groovy
+++ b/grails-app/controllers/au/org/ala/alerts/UnsubscribeController.groovy
@@ -45,9 +45,9 @@ class UnsubscribeController {
                 userAndNotifications.user.save(flush: true)
 
                 // for my annotation, we also need to delete the query and query result
-                def myAnnotationQuery = queryService.createMyAnnotationQuery(loggedInUser.userId)
+                def myAnnotationQuery = queryService.createMyAnnotationQuery(userAndNotifications.user.userId)
                 if (userAndNotifications.notifications.any { it.query.queryPath == myAnnotationQuery.queryPath }) {
-                    notificationService.deleteMyAnnotation(loggedInUser)
+                    notificationService.deleteMyAnnotation(userAndNotifications.user)
                 }
                 
                 render view: "unsubscribed"

--- a/grails-app/controllers/au/org/ala/alerts/UnsubscribeController.groovy
+++ b/grails-app/controllers/au/org/ala/alerts/UnsubscribeController.groovy
@@ -45,8 +45,8 @@ class UnsubscribeController {
                 userAndNotifications.user.save(flush: true)
 
                 // for my annotation, we also need to delete the query and query result
-                def myAnnotationQuery = queryService.createMyAnnotationQuery(userAndNotifications.user.userId)
-                if (userAndNotifications.notifications.any { it.query.queryPath == myAnnotationQuery.queryPath }) {
+                String myAnnotationQueryPath = queryService.constructMyAnnotationQueryPath(userAndNotifications.user.userId)
+                if (userAndNotifications.notifications.any { it.query.queryPath == myAnnotationQueryPath }) {
                     notificationService.deleteMyAnnotation(userAndNotifications.user)
                 }
                 

--- a/grails-app/services/au/org/ala/alerts/NotificationService.groovy
+++ b/grails-app/services/au/org/ala/alerts/NotificationService.groovy
@@ -587,8 +587,8 @@ class NotificationService {
     }
 
     def deleteMyAnnotation(User user) {
-        Query myAnnotationQuery = queryService.createMyAnnotationQuery(user?.userId)
-        Query retrievedQuery = Query.findByBaseUrlAndQueryPath(myAnnotationQuery.baseUrl, myAnnotationQuery.queryPath)
+        String myAnnotationQueryPath = queryService.constructMyAnnotationQueryPath(user?.userId)
+        Query retrievedQuery = Query.findByQueryPath(myAnnotationQueryPath)
 
         if (retrievedQuery != null) {
             // delete the notification

--- a/grails-app/services/au/org/ala/alerts/QueryService.groovy
+++ b/grails-app/services/au/org/ala/alerts/QueryService.groovy
@@ -265,10 +265,14 @@ class QueryService {
       name: messageSource.getMessage("query.myannotations.title", null, siteLocale),
       updateMessage: messageSource.getMessage("myannotations.update.message", null, siteLocale),
       description: messageSource.getMessage("query.myannotations.descr", null, siteLocale),
-      queryPath: '/occurrences/search?fq=assertion_user_id:' + userId + '&dir=desc&facets=basis_of_record',
-      queryPathForUI: '/occurrences/search?fq=assertion_user_id:' + userId + '&dir=desc&facets=basis_of_record',
+      queryPath: constructMyAnnotationQueryPath(userId),
+      queryPathForUI: constructMyAnnotationQueryPath(userId),
       emailTemplate: '/email/biocache',
       recordJsonPath: '\$.occurrences[*]',
     ])
+  }
+
+  String constructMyAnnotationQueryPath(String userId) {
+    '/occurrences/search?fq=assertion_user_id:' + userId + '&dir=desc&facets=basis_of_record'
   }
 }

--- a/src/test/groovy/au/org/ala/alerts/UnsubscribeControllerSpec.groovy
+++ b/src/test/groovy/au/org/ala/alerts/UnsubscribeControllerSpec.groovy
@@ -11,6 +11,7 @@ class UnsubscribeControllerSpec extends Specification {
 
     def setup() {
         controller.userService = Mock(UserService)
+        controller.queryService = Mock(QueryService)
     }
 
     def "index() should return a HTTP 400 (BAD_REQUEST) if there is no logged in user and no token"() {
@@ -249,6 +250,7 @@ class UnsubscribeControllerSpec extends Specification {
     def "unsubscribe() should delete all the user's notifications if the token matches the token for a user with notifications"() {
         setup:
         controller.userService.getUser() >> null
+        controller.queryService.createMyAnnotationQuery(_ as String) >> new Query([name: 'emptyquery'])
         Query query1 = newQuery("query1")
         Query query2 = newQuery("query2")
         User user1 = new User(userId: "user1", email: "fred@bla.com")
@@ -285,6 +287,7 @@ class UnsubscribeControllerSpec extends Specification {
     def "unsubscribe() should delete only 1 notification if the token matches the token for a notification"() {
         setup:
         controller.userService.getUser() >> null
+        controller.queryService.createMyAnnotationQuery(_ as String) >> new Query([name: 'emptyquery'])
         Query query1 = newQuery("query1")
         Query query2 = newQuery("query2")
         User user = new User(userId: "user1", email: "fred@bla.com")
@@ -323,6 +326,7 @@ class UnsubscribeControllerSpec extends Specification {
         user.addToNotifications(notification2)
         user.save(failOnError: true, flush: true)
         controller.userService.getUser() >> user
+        controller.queryService.createMyAnnotationQuery(_ as String) >> new Query([name: 'emptyquery'])
 
         when:
         params.token = notification1.unsubscribeToken


### PR DESCRIPTION
https://github.com/AtlasOfLivingAustralia/alerts/issues/100

when unsubscribe old code only removes notifications and update user.

for myannotation, we need to also delete the query and queryresult