### PR TITLE
need to run a myannotation query after it's added

### DIFF
--- a/grails-app/services/au/org/ala/alerts/QueryService.groovy
+++ b/grails-app/services/au/org/ala/alerts/QueryService.groovy
@@ -88,12 +88,15 @@ class QueryService {
     toBeRemoved.size()
   }
 
-  def createQueryForUserIfNotExists(Query newQuery, User user, boolean setPropertyPath = true){
+  // return true if a new query is created, otherwise return false
+  boolean createQueryForUserIfNotExists(Query newQuery, User user, boolean setPropertyPath = true) {
+    boolean newQueryCreated = false
     //find the query
     Query retrievedQuery = Query.findByBaseUrlAndQueryPath(newQuery.baseUrl, newQuery.queryPath)
     if (retrievedQuery == null) {
       try {
         newQuery = newQuery.save(true)
+        newQueryCreated = true
         if (setPropertyPath) {
           new PropertyPath([name: "totalRecords", jsonPath: "totalRecords", query: newQuery, fireWhenNotZero: true]).save(true)
           new PropertyPath([name: "last_loaded_record", jsonPath: "occurrences[0].rowKey", query: newQuery]).save(true)
@@ -116,6 +119,8 @@ class QueryService {
         n.errors.allErrors.each { e -> println(e)}
       }
     }
+
+    newQueryCreated
   }
 
   /**

--- a/grails-app/services/au/org/ala/alerts/QueryService.groovy
+++ b/grails-app/services/au/org/ala/alerts/QueryService.groovy
@@ -115,8 +115,8 @@ class QueryService {
       Notification n = new Notification([query: newQuery, user: user])
       n.save(true)
       
-      if(n.hasErrors()){
-        n.errors.allErrors.each { e -> println(e)}
+      if (n.hasErrors()) {
+        n.errors.allErrors.each { e -> log.error(e) }
       }
     }
 


### PR DESCRIPTION
for issue https://github.com/AtlasOfLivingAustralia/alerts/issues/111

With the current implementation, any admin verification that happens before 1st scheduled check will be missed.

Drew a picture that is easy to understand.

![1](https://user-images.githubusercontent.com/61677987/114491967-f36e1680-9c5a-11eb-9bc3-b90929da8296.jpg)

