### PR TITLE
if user subscribed to 'My Annotation' and changes frequency, we need …

### DIFF
--- a/grails-app/controllers/au/org/ala/alerts/NotificationController.groovy
+++ b/grails-app/controllers/au/org/ala/alerts/NotificationController.groovy
@@ -96,8 +96,7 @@ class NotificationController {
     def changeFrequency = {
         def user = userService.getUser()
         log.debug("Changing frequency to: " + params.frequency + " for user ${user}")
-        user.frequency = Frequency.findByName(params.frequency)
-        user.save(flush: true)
+        notificationService.updateFrequency(user, params.frequency)
         return null
     }
 


### PR DESCRIPTION
…to trigger a query for 'my annotation'

for issue https://github.com/AtlasOfLivingAustralia/alerts/issues/113

This is similar to https://github.com/AtlasOfLivingAustralia/alerts/issues/111,

Idea is, for 'my annotation' when it's created (subscribed) or frequency changed (the old query result is then useless since query result is frequency-specific) we need to insert a queryResult.