### PR TITLE
Feature/import rds snapshot

### DIFF
--- a/cicd/database/app/database.yaml
+++ b/cicd/database/app/database.yaml
@@ -60,6 +60,7 @@ Parameters:
   pRdsSnapshotRestore:
     Description: The snapshot to restore from
     Type: String
+    Default: false
   pVpcStackName:
     Description: The name of the Bedrock VPC stack
     Type: String

--- a/cicd/database/app/database.yaml
+++ b/cicd/database/app/database.yaml
@@ -230,13 +230,13 @@ Resources:
   ErrorLogGroup:
     Type: AWS::Logs::LogGroup
     Properties: 
-      LogGroupName: !Sub /aws/rds/cluster/${pDbInstanceName}-cluster/error
+      LogGroupName: !Sub aws/rds/cluster/${pDbInstanceName}-cluster/error
       RetentionInDays: 30
 
   SlowQueryLogGroup:
     Type: AWS::Logs::LogGroup
     Properties: 
-      LogGroupName: !Sub /aws/rds/cluster/${pDbInstanceName}-cluster/slowquery
+      LogGroupName: !Sub aws/rds/cluster/${pDbInstanceName}-cluster/slowquery
       RetentionInDays: 30
 
 

--- a/cicd/database/app/database.yaml
+++ b/cicd/database/app/database.yaml
@@ -230,13 +230,14 @@ Resources:
   ErrorLogGroup:
     Type: AWS::Logs::LogGroup
     Properties: 
-      LogGroupName: !Sub aws/rds/cluster/${pDbInstanceName}-cluster/error
+      LogGroupName: !Sub /aws/rds/cluster/${pDbInstanceName}-cluster/error
+      
       RetentionInDays: 30
 
   SlowQueryLogGroup:
     Type: AWS::Logs::LogGroup
     Properties: 
-      LogGroupName: !Sub aws/rds/cluster/${pDbInstanceName}-cluster/slowquery
+      LogGroupName: !Sub /aws/rds/cluster/${pDbInstanceName}-cluster/slowquery
       RetentionInDays: 30
 
 

--- a/cicd/database/app/database.yaml
+++ b/cicd/database/app/database.yaml
@@ -57,6 +57,9 @@ Parameters:
     AllowedValues:
       - true
       - false
+  pRdsSnapshotRestore:
+    Description: The snapshot to restore from
+    Type: String
   pVpcStackName:
     Description: The name of the Bedrock VPC stack
     Type: String
@@ -68,6 +71,10 @@ Conditions:
   IsDev: !Equals
             - !Ref pEnvironment
             - development
+  RestoreFromSnapshot: !Not
+                          - !Equals
+                              - !Ref pRdsSnapshotRestore
+                              - false
 
 Resources:
 
@@ -131,6 +138,7 @@ Resources:
     Properties:
       BacktrackWindow: !Ref pBacktrackWindow
       BackupRetentionPeriod: !Ref pBackupRetention
+      CopyTagsToSnapshot: true
       DatabaseName: !Sub ${pProductName}${pEnvironment}
       DBClusterIdentifier: !Sub ${pDbInstanceName}-cluster
       DBClusterParameterGroupName: !Ref ClusterParamGrp
@@ -149,7 +157,7 @@ Resources:
       Port: 3306
       PreferredBackupWindow: 16:00-17:00
       PreferredMaintenanceWindow: tue:17:00-tue:19:00
-      #SnapshotIdentifier: !Ref RdsSnapshot
+      SnapshotIdentifier: !If [ RestoreFromSnapshot, !Ref pRdsSnapshotRestore, !Ref "AWS::NoValue" ]
       Tags:
         - Key: Name
           Value: Alerts DB Cluster

--- a/cicd/database/app/database.yaml
+++ b/cicd/database/app/database.yaml
@@ -72,6 +72,9 @@ Conditions:
   IsDev: !Equals
             - !Ref pEnvironment
             - development
+  IsProd: !Equals
+            - !Ref pEnvironment
+            - production
   RestoreFromSnapshot: !Not
                           - !Equals
                               - !Ref pRdsSnapshotRestore
@@ -134,8 +137,11 @@ Resources:
 
   DbCluster:
     Type: "AWS::RDS::DBCluster"
-    UpdateReplacePolicy: Snapshot
-    DeletionPolicy: Snapshot
+    UpdateReplacePolicy: !If [ IsProd, "Snapshot", "Delete" ]
+    DeletionPolicy: !If [ IsProd, "Snapshot", "Delete" ]
+    DependsOn:
+         - SlowQueryLogGroup
+         - ErrorLogGroup
     Properties:
       BacktrackWindow: !Ref pBacktrackWindow
       BackupRetentionPeriod: !Ref pBackupRetention
@@ -231,7 +237,6 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties: 
       LogGroupName: !Sub /aws/rds/cluster/${pDbInstanceName}-cluster/error
-      
       RetentionInDays: 30
 
   SlowQueryLogGroup:

--- a/cicd/database/app/database_template_config.j2
+++ b/cicd/database/app/database_template_config.j2
@@ -13,6 +13,7 @@
     "pInstanceClass"       : "{{ instance_class }}",
     "pPerformanceInsights" : "{{ performance_insights }}",
     "pProductName"         : "{{ product_name }}",
+    "pRdsSnapshotRestore"  : "{{ rds_snapshot_restore }}",
     "pVpcStackName"        : "{{ vpc_stack_name }}"
   },
   "Tags" : {

--- a/cicd/database/config.ini
+++ b/cicd/database/config.ini
@@ -13,7 +13,7 @@ BACKTRACK_WINDOW = 86400
 BACKUP_RETENTION = 1
 CREATE_REPLICA = false
 DB_INSTANCE_NAME = alerts-${ENVIRONMENT}
-DB_VERSION = 8.0.mysql_aurora.3.07.0
+DB_VERSION = 8.0.mysql_aurora.3.07.1
 DELETION_PROTECTION = false
 INSTANCE_CLASS = db.t4g.medium
 PERFORMANCE_INSIGHTS = false
@@ -31,7 +31,7 @@ AUTO_DEPLOY = true
 
 # RDS
 DB_INSTANCE_NAME = alerts-${CLEAN_BRANCH}
-RDS_SNAPSHOT_RESTORE = arn:aws:rds:ap-southeast-2:748909248546:cluster-snapshot:ala-alerts-database-feature-rds-pipeline-updates-snapshot-dbcluster-wpangbshgwib
+RDS_SNAPSHOT_RESTORE = arn:aws:rds:ap-southeast-2:748909248546:cluster-snapshot:rds:alerts-ci-code-pipeline-cluster-2024-08-18-16-12
 
 [testing]
 

--- a/cicd/database/config.ini
+++ b/cicd/database/config.ini
@@ -31,7 +31,7 @@ AUTO_DEPLOY = true
 
 # RDS
 DB_INSTANCE_NAME = alerts-${CLEAN_BRANCH}
-RDS_SNAPHOT_RESTORE = arn:aws:rds:ap-southeast-2:748909248546:cluster-snapshot:ala-alerts-database-feature-rds-pipeline-updates-snapshot-dbcluster-wpangbshgwib
+#RDS_SNAPHOT_RESTORE = arn:aws:rds:ap-southeast-2:748909248546:cluster-snapshot:ala-alerts-database-feature-rds-pipeline-updates-snapshot-dbcluster-wpangbshgwib
 
 [testing]
 

--- a/cicd/database/config.ini
+++ b/cicd/database/config.ini
@@ -31,10 +31,18 @@ AUTO_DEPLOY = true
 
 # RDS
 DB_INSTANCE_NAME = alerts-${CLEAN_BRANCH}
-#RDS_SNAPSHOT_RESTORE = arn:aws:rds:ap-southeast-2:748909248546:cluster-snapshot:rds:alerts-ci-code-pipeline-cluster-2024-08-18-16-12
+INSTANCE_CLASS = db.t4g.small
+#RDS_SNAPSHOT_RESTORE = arn:aws:rds:ap-southeast-2:748909248546:cluster-snapshot:ala-alerts-database-feature-rds-pipeline-updates-snapshot-dbcluster-wpangbshgwib
 
 [testing]
+# RDS
+INSTANCE_CLASS = db.t4g.small
 
 [staging]
+# RDS
+PERFORMANCE_INSIGHTS = true
 
 [production]
+# RDS
+DELETION_PROTECTION = true
+PERFORMANCE_INSIGHTS = true

--- a/cicd/database/config.ini
+++ b/cicd/database/config.ini
@@ -31,7 +31,7 @@ AUTO_DEPLOY = true
 
 # RDS
 DB_INSTANCE_NAME = alerts-${CLEAN_BRANCH}
-RDS_SNAPSHOT_RESTORE = arn:aws:rds:ap-southeast-2:748909248546:cluster-snapshot:rds:alerts-ci-code-pipeline-cluster-2024-08-18-16-12
+#RDS_SNAPSHOT_RESTORE = arn:aws:rds:ap-southeast-2:748909248546:cluster-snapshot:rds:alerts-ci-code-pipeline-cluster-2024-08-18-16-12
 
 [testing]
 

--- a/cicd/database/config.ini
+++ b/cicd/database/config.ini
@@ -17,6 +17,7 @@ DB_VERSION = 8.0.mysql_aurora.3.07.0
 DELETION_PROTECTION = false
 INSTANCE_CLASS = db.t4g.medium
 PERFORMANCE_INSIGHTS = false
+# The snapshot ARN to restore the database from. Set to "false" to not use a snapshot.
 RDS_SNAPHOT_RESTORE = false
 
 
@@ -30,6 +31,7 @@ AUTO_DEPLOY = true
 
 # RDS
 DB_INSTANCE_NAME = alerts-${CLEAN_BRANCH}
+RDS_SNAPHOT_RESTORE = arn:aws:rds:ap-southeast-2:748909248546:cluster-snapshot:ala-alerts-database-feature-rds-pipeline-updates-snapshot-dbcluster-wpangbshgwib
 
 [testing]
 

--- a/cicd/database/config.ini
+++ b/cicd/database/config.ini
@@ -17,6 +17,7 @@ DB_VERSION = 8.0.mysql_aurora.3.07.0
 DELETION_PROTECTION = false
 INSTANCE_CLASS = db.t4g.medium
 PERFORMANCE_INSIGHTS = false
+RDS_SNAPHOT_RESTORE = false
 
 
 [development]

--- a/cicd/database/config.ini
+++ b/cicd/database/config.ini
@@ -18,7 +18,7 @@ DELETION_PROTECTION = false
 INSTANCE_CLASS = db.t4g.medium
 PERFORMANCE_INSIGHTS = false
 # The snapshot ARN to restore the database from. Set to "false" to not use a snapshot.
-RDS_SNAPHOT_RESTORE = false
+RDS_SNAPSHOT_RESTORE = false
 
 
 [development]
@@ -31,7 +31,7 @@ AUTO_DEPLOY = true
 
 # RDS
 DB_INSTANCE_NAME = alerts-${CLEAN_BRANCH}
-#RDS_SNAPHOT_RESTORE = arn:aws:rds:ap-southeast-2:748909248546:cluster-snapshot:ala-alerts-database-feature-rds-pipeline-updates-snapshot-dbcluster-wpangbshgwib
+RDS_SNAPSHOT_RESTORE = arn:aws:rds:ap-southeast-2:748909248546:cluster-snapshot:ala-alerts-database-feature-rds-pipeline-updates-snapshot-dbcluster-wpangbshgwib
 
 [testing]
 

--- a/cicd/database/config.ini
+++ b/cicd/database/config.ini
@@ -31,12 +31,10 @@ AUTO_DEPLOY = true
 
 # RDS
 DB_INSTANCE_NAME = alerts-${CLEAN_BRANCH}
-INSTANCE_CLASS = db.t4g.small
 #RDS_SNAPSHOT_RESTORE = arn:aws:rds:ap-southeast-2:748909248546:cluster-snapshot:ala-alerts-database-feature-rds-pipeline-updates-snapshot-dbcluster-wpangbshgwib
 
 [testing]
 # RDS
-INSTANCE_CLASS = db.t4g.small
 
 [staging]
 # RDS


### PR DESCRIPTION
Add the option to import an RDS snapshot when the DB is being created. Once you choose to enable or disable snapshot import you must keep that setting the same for the life of the branch, otherwise the database will be destroyed and recreated with the new setting. [Details are here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html#cfn-rds-dbcluster-snapshotidentifier)

Other updates in this PR
- Create Cloudwatch log groups before the cluster, other wise they can be auto created by the cluster and wont have the settings we want
- Only take an automatic deletion snapshot when in production
- Added environment specific settings like deletion protection and performance insights in production
- Updated Aurora version to 8.0.mysql_aurora.3.07.1