### PR TITLE
update build container

### DIFF
--- a/cicd/build/pipeline/pipeline.yaml
+++ b/cicd/build/pipeline/pipeline.yaml
@@ -94,7 +94,7 @@ Resources:
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:5.0
+        Image: aws/codebuild/standard:7.0
       Source:
         Type: CODEPIPELINE
         BuildSpec: !Sub cicd/${pProductComponent}/pipeline/build_alerts_buildspec.yaml


### PR DESCRIPTION
I was helping Yasima with a userdetails build issue and noticed it was on an older Ubuntu 20.04 build container, updating it to the latest fixed the issue. I must have missed it here