### PR TITLE
Feature/302 aws s3 infrastructure request

### DIFF
--- a/cicd/base/app/base.yaml
+++ b/cicd/base/app/base.yaml
@@ -110,7 +110,6 @@ Resources:
       Description: !Sub 'Ec2 instance profile role for ${AWS::StackName} ${pEnvironment} build ${pBuild}'
       ManagedPolicyArns:
         - !Sub arn:aws:iam::${AWS::AccountId}:policy/cpt/cptSSMInstanceCoreCloudWatchPatch
-        - arn:aws:iam::aws:policy/AmazonCognitoPowerUser
       Policies:
         - PolicyDocument:
             Version: "2012-10-17"
@@ -200,6 +199,8 @@ Outputs:
 
   AlertsSecret:
     Description: The Secrets name for alerts 
-    Value: !Sub 
-            - alerts-${ResourceName}
-            - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
+    Value: !Ref AlertsSecret 
+  
+  BiosecurityAlertsBucket:
+    Description: The S3 bucket for the Biosecurity Alerts service
+    Value: !Ref BiosecurityAlertsBucket

--- a/cicd/base/app/base.yaml
+++ b/cicd/base/app/base.yaml
@@ -108,12 +108,9 @@ Resources:
         ExcludeCharacters: "/@\" "
         SecretStringTemplate: |
           {
-            "db-password": ""
+            "db-password": "",
+            "oidc_secret" : ""
           }
-      SecretString: |
-                {
-                   "oidc_secret" : ""
-                }
 
 
 

--- a/cicd/base/app/base.yaml
+++ b/cicd/base/app/base.yaml
@@ -44,7 +44,7 @@ Resources:
       ImageScanningConfiguration:
         ScanOnPush: true
       RepositoryName: !Sub
-                         - alerts-${ResourceName}
+                         - ${pProductName}-${ResourceName}
                          - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
       RepositoryPolicyText:
         Version: 2012-10-17

--- a/cicd/base/app/base.yaml
+++ b/cicd/base/app/base.yaml
@@ -28,8 +28,7 @@ Conditions:
     - !Equals
       - !Ref pEnvironment
       - production
-  #IsFirstBuild: !Equals [!Ref pBuild, "1"]
-  IsFirstBuild: !Equals ["1", "1"]
+  IsFirstBuild: !Equals [!Ref pBuild, "1"]
 
 Resources:
 

--- a/cicd/base/app/base.yaml
+++ b/cicd/base/app/base.yaml
@@ -28,7 +28,8 @@ Conditions:
     - !Equals
       - !Ref pEnvironment
       - production
-  IsFirstBuild: !Equals [!Ref pBuild, "1"]
+  #IsFirstBuild: !Equals [!Ref pBuild, "1"]
+  IsFirstBuild: !Equals ["1", "1"]
 
 Resources:
 

--- a/cicd/base/app/base.yaml
+++ b/cicd/base/app/base.yaml
@@ -63,7 +63,7 @@ Resources:
           Value: !Ref pCleanBranch
 
   BiosecurityAlertsBucket:
-    Type: "AWS::S3::Bucket"
+    Type: AWS::S3::Bucket
     DeletionPolicy: Delete
     Properties:
       BucketEncryption:
@@ -78,11 +78,6 @@ Resources:
           - Id: delete
             AbortIncompleteMultipartUpload:
                DaysAfterInitiation: 1
-            Status: Enabled
-          - Id: storage class transition
-            Transition:
-              StorageClass: INTELLIGENT_TIERING
-              TransitionInDays: 7
             Status: Enabled
       PublicAccessBlockConfiguration:
         BlockPublicAcls: TRUE
@@ -170,7 +165,7 @@ Resources:
  
 
   AlertsSecret:
-    Type: 'AWS::SecretsManager::Secret'
+    Type: AWS::SecretsManager::Secret
     Properties:
       Name: !Sub 
               - ${pProductName}-${ResourceName}

--- a/cicd/base/app/base.yaml
+++ b/cicd/base/app/base.yaml
@@ -12,6 +12,12 @@ Parameters:
   pEnvironment:
     Type: String
     Description: The AWS environment this belongs to
+  pProductComponent:
+    Type: String
+    Description: The product component
+  pProductName:
+    Type: String
+    Description: The name of the product
 
 Conditions:
 
@@ -22,6 +28,7 @@ Conditions:
     - !Equals
       - !Ref pEnvironment
       - production
+  IsFirstBuild: !Equals [!Ref pBuild, "1"]
 
 Resources:
 
@@ -52,11 +59,46 @@ Resources:
         - Key: Branch
           Value: !Ref pCleanBranch
 
+  BiosecurityAlertsBucket:
+    Type: "AWS::S3::Bucket"
+    DeletionPolicy: Delete
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      BucketName: !Sub 
+              - ${pProductName}-${ResourceName}
+              - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
+      LifecycleConfiguration:
+        Rules:
+          - Id: delete
+            AbortIncompleteMultipartUpload:
+               DaysAfterInitiation: 1
+            Status: Enabled
+          - Id: storage class transition
+            Transition:
+              StorageClass: INTELLIGENT_TIERING
+              TransitionInDays: 7
+            Status: Enabled
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: TRUE
+        BlockPublicPolicy: TRUE
+        IgnorePublicAcls: TRUE
+        RestrictPublicBuckets: TRUE
+      Tags:
+        - Key: Name
+          Value: !Sub 
+              - ${pProductName}-${ResourceName}
+              - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
+        
+
   AlertsSecret:
     Type: 'AWS::SecretsManager::Secret'
+    Condition: IsFirstBuild
     Properties:
       Name: !Sub 
-              - alerts-${ResourceName}
+              - ${pProductName}-${ResourceName}
               - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
       Description: !Sub Alerts app ${pEnvironment} secrets
       GenerateSecretString: 
@@ -67,6 +109,10 @@ Resources:
           {
             "db-password": ""
           }
+      SecretString: |
+                {
+                   "oidc_secret" : ""
+                }
 
 
 
@@ -82,4 +128,6 @@ Outputs:
 
   AlertsSecret:
     Description: The Secrets name for alerts 
-    Value: !Ref AlertsSecret
+    Value: !Sub 
+            - alerts-${ResourceName}
+            - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]

--- a/cicd/base/app/base.yaml
+++ b/cicd/base/app/base.yaml
@@ -141,12 +141,27 @@ Resources:
             Statement:
             - Effect: Allow
               Action:
+                - s3:DeleteObject
+                - s3:DeleteObjectVersion
+                - s3:GetBucketLocation
+                - s3:GetObject
+                - s3:ListBucket
+                - s3:PutObject
+              Resource:
+                - !Sub arn:aws:s3:::${BiosecurityAlertsBucket}
+                - !Sub arn:aws:s3:::${BiosecurityAlertsBucket}/*
+          PolicyName: biosecurity-bucket
+        - PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              Action:
                 - ses:SendEmail
                 - ses:SendTemplatedEmail
                 - ses:SendRawEmail
               Resource:
                 - '*'
-          PolicyName: backups
+          PolicyName: email
       RoleName: !Sub '${AWS::StackName}--${pEnvironment}--${pBuild}'
       Tags:
         - Key: Name

--- a/cicd/base/app/base.yaml
+++ b/cicd/base/app/base.yaml
@@ -6,6 +6,9 @@ Parameters:
   pBuild:
     Type: String
     Description: The build number
+  pBackupBucket:
+    Type: String
+    Description: The backup bucket
   pCleanBranch:
     Type: String
     Description: The clean branch, can be used in resource names
@@ -28,8 +31,7 @@ Conditions:
     - !Equals
       - !Ref pEnvironment
       - production
-  #IsFirstBuild: !Equals [!Ref pBuild, "1"]
-  IsFirstBuild: !Equals ["1", "1"]
+  IsFirstBuild: !Equals [!Ref pBuild, "1"]
 
 Resources:
 
@@ -92,7 +94,66 @@ Resources:
           Value: !Sub 
               - ${pProductName}-${ResourceName}
               - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
-        
+
+  AlertsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - ec2.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      Description: !Sub 'Ec2 instance profile role for ${AWS::StackName} ${pEnvironment} build ${pBuild}'
+      ManagedPolicyArns:
+        - !Sub arn:aws:iam::${AWS::AccountId}:policy/cpt/cptSSMInstanceCoreCloudWatchPatch
+        - arn:aws:iam::aws:policy/AmazonCognitoPowerUser
+      Policies:
+        - PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              Action:
+                - 'secretsmanager:getsecretvalue'
+              Resource:
+                - !Sub ${AlertsSecret}-??????
+          PolicyName: secrets
+        - PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              Action:
+                - s3:DeleteObject
+                - s3:DeleteObjectVersion
+                - s3:GetBucketLocation
+                - s3:GetObject
+                - s3:ListBucket
+                - s3:PutObject
+              Resource:
+                - !Sub arn:aws:s3:::${pBackupBucket}
+                - !Sub arn:aws:s3:::${pBackupBucket}/*
+          PolicyName: backups
+        - PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              Action:
+                - ses:SendEmail
+                - ses:SendTemplatedEmail
+                - ses:SendRawEmail
+              Resource:
+                - '*'
+          PolicyName: backups
+      RoleName: !Sub '${AWS::StackName}--${pEnvironment}--${pBuild}'
+      Tags:
+        - Key: Name
+          Value: !Sub 
+              - ${pProductName}-${ResourceName}
+              - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
+ 
 
   AlertsSecret:
     Type: 'AWS::SecretsManager::Secret'

--- a/cicd/base/app/base.yaml
+++ b/cicd/base/app/base.yaml
@@ -28,7 +28,8 @@ Conditions:
     - !Equals
       - !Ref pEnvironment
       - production
-  IsFirstBuild: !Equals [!Ref pBuild, "1"]
+  #IsFirstBuild: !Equals [!Ref pBuild, "1"]
+  IsFirstBuild: !Equals ["1", "1"]
 
 Resources:
 
@@ -95,21 +96,19 @@ Resources:
 
   AlertsSecret:
     Type: 'AWS::SecretsManager::Secret'
-    Condition: IsFirstBuild
     Properties:
       Name: !Sub 
               - ${pProductName}-${ResourceName}
               - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
       Description: !Sub Alerts app ${pEnvironment} secrets
-      GenerateSecretString: 
-        GenerateStringKey: db-password
-        PasswordLength: 12
-        ExcludeCharacters: "/@\" "
-        SecretStringTemplate: |
-          {
-            "db-password": "",
-            "oidc_secret" : ""
-          }
+      SecretString: !If
+              - IsFirstBuild
+              - |
+                {
+                   "oidc_secret" : "",
+                   "db-password" : "",
+                }
+              - !Ref "AWS::NoValue"
 
 
 

--- a/cicd/base/app/base_template_config.j2
+++ b/cicd/base/app/base_template_config.j2
@@ -1,6 +1,7 @@
 {
   "Parameters" : {
     "pBuild"                : "{{ codebuild_build_number }}",
+    "pBackupBucket"          : "{{ backup_bucket }}",
     "pCleanBranch"          : "{{ clean_branch }}",
     "pEnvironment"          : "{{ environment }}",
     "pProductComponent"     : "{{ product_component }}",

--- a/cicd/base/app/base_template_config.j2
+++ b/cicd/base/app/base_template_config.j2
@@ -2,7 +2,9 @@
   "Parameters" : {
     "pBuild"                : "{{ codebuild_build_number }}",
     "pCleanBranch"          : "{{ clean_branch }}",
-    "pEnvironment"          : "{{ environment }}"
+    "pEnvironment"          : "{{ environment }}",
+    "pProductComponent"     : "{{ product_component }}",
+    "pProductName"          : "{{ product_name }}"
   },
   "Tags" : {
     "product"     : "{{ product_name }}",

--- a/cicd/base/config.ini
+++ b/cicd/base/config.ini
@@ -6,6 +6,7 @@ BASE_STACK_NAME = ala-${PRODUCT_NAME}-${PRODUCT_COMPONENT}-${ENVIRONMENT}
 AUTO_DEPLOY = false
 SLACK_DEPLOY_NOTIFICATION = false
 SLACK_ALERT_CHANNEL = deployments
+BACKUP_BUCKET = ala-backup-alerts
 
 [development]
 # code pipeline

--- a/cicd/base/pipeline/empty_bucket_buildspec.yaml
+++ b/cicd/base/pipeline/empty_bucket_buildspec.yaml
@@ -1,0 +1,13 @@
+version: 0.2
+###
+# Deletes all objects from the biosecurity alerts bucket, this needs to be done 
+# before the teardown action so the bucket can be removed
+
+env:
+  shell: bash
+
+phases:
+  build:
+    commands:
+      - echo The alerts bucket is $BIOSECURITY_ALERTS_BUCKET, deleting all objects
+      - aws s3 rm s3://$BIOSECURITY_ALERTS_BUCKET --recursive

--- a/cicd/base/pipeline/pipeline.yaml
+++ b/cicd/base/pipeline/pipeline.yaml
@@ -100,6 +100,27 @@ Resources:
         BuildSpec: !Sub cicd/${pProductComponent}/pipeline/deploy_notification_buildspec.yaml
       TimeoutInMinutes: 5
 
+  EmptyBucket:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub 
+              - ${pProductName}-${pProductComponent}-empty-bucket-${ResourceName}
+              - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
+      Description: Empty the biosecurity alerts bucket for teardown
+      ServiceRole:
+               Fn::ImportValue:
+                 Fn::Sub: ${pBootstrapStackName}-CodeBuildServiceRoleArn
+      Artifacts:                           
+        Type: CODEPIPELINE                 
+      Environment:                         
+        Type: LINUX_CONTAINER              
+        ComputeType: BUILD_GENERAL1_SMALL  
+        Image: aws/codebuild/standard:7.0  
+      Source:                             
+        Type: CODEPIPELINE
+        BuildSpec: !Sub cicd/${pProductComponent}/pipeline/empty_bucket_buildspec.yaml
+      TimeoutInMinutes: 5
+
   Pipeline:
     Type: "AWS::CodePipeline::Pipeline"
     Properties:
@@ -178,7 +199,7 @@ Resources:
                  ]
             Namespace: ExportConfigNS
             InputArtifacts:
-              - Name: 'SourceArtifact'
+              - Name: SourceArtifact
             OutputArtifacts:
               - Name: ExportConfigArtifact
             RunOrder: 1
@@ -199,7 +220,7 @@ Resources:
                      Fn::Sub: '${pBootstrapStackName}-CloudFormationServiceRoleArn'
               StackName: '#{ExportConfigNS.BASE_STACK_NAME}'
             InputArtifacts:
-              - Name: 'ExportConfigArtifact'
+              - Name: ExportConfigArtifact
             Namespace: BaseCloudFormationOutNS
             OutputArtifacts: [ ]
             RunOrder: 2
@@ -241,6 +262,24 @@ Resources:
             Configuration:
               CustomData: Approval required to tear down this stack
             RunOrder: 1
+          - Name: EmptyBucket
+            ActionTypeId:
+              Owner: AWS
+              Category: Build
+              Version: 1
+              Provider: CodeBuild
+            Configuration:
+              ProjectName: !Ref EmptyBucket
+              EnvironmentVariables: |
+                 [
+                   { "name":"BIOSECURITY_ALERTS_BUCKET", "value":"#{BaseCloudFormationOutNS.BiosecurityAlertsBucket}" }
+                 ]
+            Namespace: EmptyBucketNS
+            InputArtifacts:
+              - Name: SourceArtifact
+            OutputArtifacts:
+              - Name: EmptyBucketArtifact
+            RunOrder: 2
           - Name: TeardownBaseStack
             ActionTypeId:
               Owner: AWS
@@ -253,7 +292,7 @@ Resources:
               RoleArn:
                 Fn::ImportValue:
                   Fn::Sub: '${pBootstrapStackName}-CloudFormationServiceRoleArn'
-            RunOrder: 2
+            RunOrder: 3
           - Name: ApprovalForPipelineTeardown
             ActionTypeId:
               Owner: AWS
@@ -262,7 +301,7 @@ Resources:
               Provider: Manual
             Configuration:
               CustomData: Approval required to tear down this stack
-            RunOrder: 3
+            RunOrder: 4
           - Name: TeardownCodePipeline
             ActionTypeId:
               Owner: AWS
@@ -275,7 +314,7 @@ Resources:
               RoleArn:
                    Fn::ImportValue:
                      Fn::Sub: '${pBootstrapStackName}-CloudFormationServiceRoleArn'
-            RunOrder: 4
+            RunOrder: 5
 
   ExportConfigCodeBuildLogGroup:
     Type: AWS::Logs::LogGroup
@@ -297,6 +336,15 @@ Resources:
         - Key: Name
           Value: !Ref AWS::StackName
 
+  EmptyBucketLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    Properties:
+      LogGroupName: !Sub /aws/codebuild/${EmptyBucket}
+      RetentionInDays: 30
+      Tags:
+        - Key: Name
+          Value: !Ref AWS::StackName
 
 Outputs:
   PipelineUrl:

--- a/config.ini
+++ b/config.ini
@@ -10,32 +10,14 @@ BUCKETS_STACK_NAME = ala-bedrock-cicd-buckets-production
 VPC_STACK_NAME = ala-bedrock-vpc-production
 
 [development]
-# code pipeline
-CODESTAR_CONNECTION = arn:aws:codestar-connections:ap-southeast-2:748909248546:connection/e336fd41-54c2-42e1-97c9-cbd6cc09fe88
-ARTIFACTS_BUCKET = ala-code-pipeline-artifacts-748909-ap-southeast-2-production
-CLOUDFORMATION_SERVICE_ROLE = arn:aws:iam::748909248546:role/cloud-formation-service-role-production
-CODEBUILD_SERVICE_ROLE = arn:aws:iam::748909248546:role/service-role/code-build-service-role-production
-CODEPIPELINE_SERVICE_ROLE = arn:aws:iam::748909248546:role/code-pipeline-service-role-production
 ALERTS_ECR_REPOSITORY = 748909248546.dkr.ecr.ap-southeast-2.amazonaws.com/ala-alerts
 EKS_CLUSTER_NAME = testing
 
 [testing]
-# code pipeline
-CODESTAR_CONNECTION = arn:aws:codestar-connections:ap-southeast-2:748909248546:connection/e336fd41-54c2-42e1-97c9-cbd6cc09fe88
-ARTIFACTS_BUCKET = ala-code-pipeline-artifacts-748909-ap-southeast-2-production
-CLOUDFORMATION_SERVICE_ROLE = arn:aws:iam::748909248546:role/cloud-formation-service-role-production
-CODEBUILD_SERVICE_ROLE = arn:aws:iam::748909248546:role/service-role/code-build-service-role-production
-CODEPIPELINE_SERVICE_ROLE = arn:aws:iam::748909248546:role/code-pipeline-service-role-production'
 ALERTS_ECR_REPOSITORY = 748909248546.dkr.ecr.ap-southeast-2.amazonaws.com/ala-alerts
 EKS_CLUSTER_NAME = testing
 
 [staging]
-# code pipeline
-CODESTAR_CONNECTION = arn:aws:codestar-connections:ap-southeast-2:736913556139:connection/a13c92b1-cb4e-437e-ad63-d6035c67fe77
-ARTIFACTS_BUCKET = ala-code-pipeline-artifacts-736913-ap-southeast-2-production
-CLOUDFORMATION_SERVICE_ROLE = arn:aws:iam::736913556139:role/cloud-formation-service-role-production
-CODEBUILD_SERVICE_ROLE = arn:aws:iam::736913556139:role/service-role/code-build-service-role-production
-CODEPIPELINE_SERVICE_ROLE = arn:aws:iam::736913556139:role/code-pipeline-service-role-production
 ALERTS_ECR_REPOSITORY = 736913556139.dkr.ecr.ap-southeast-2.amazonaws.com/ala-alerts
 EKS_CLUSTER_NAME = testing
 


### PR DESCRIPTION
- Adds a biosecurity alerts bucket and also a IAM role for an Ec2 instance with permissions to access it.

The IAM role contains all the permissions on the existing alerts assume role as well so after this goes out it can replace that, it's currently manual and unmanaged.

The Ec2 instance is also not under management yet ( might never be as we move to containers ) so this role still has to be manually added to the Ec2 instance

This same role could be used by the container version of alerts as well, may have to modify the AssumeRolePolicyDocument of the role [like it is in Userdetails](https://github.com/AtlasOfLivingAustralia/userdetails/blob/feature/containerization/cicd/base/app/base.yaml#L139-L157)

- Made it so that the secrets are only created the first time the base stack runs, this prevents the secret values being overwritten each time the base infrastructure is deployed. I couldnt work out a neat way to retain the auto generated DB password when doing this. It means you have to manually fill in a DB password in secrets manager after first deploying the base infrastructure. It's a bit of a trade off and more leaning towards keeping production safe, we dont ever want to overwrite secrets once it's been deployed live.
- Deleted all the old pre Bedrock vars from config.ini, there's a bunch more stuff that can be done but that was just a quick one. [More here](https://github.com/AtlasOfLivingAustralia/alerts/issues/304)