### PR TITLE
update regolith stack name

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -10,14 +10,13 @@ BUCKETS_STACK_NAME = ala-bedrock-cicd-buckets-production
 VPC_STACK_NAME = ala-bedrock-vpc-production
 
 [development]
-REGOLITH_STACK_NAME = ala-regolith-cluster-testing-testing
+REGOLITH_STACK_NAME = ala-regolith-cluster-testing
 
 [testing]
-REGOLITH_STACK_NAME = ala-regolith-cluster-testing-testing
+REGOLITH_STACK_NAME = ala-regolith-cluster-testing
 
 [staging]
 REGOLITH_STACK_NAME = ala-regolith-cluster-staging
 
 [production]
-# code pipeline
 REGOLITH_STACK_NAME = ala-regolith-cluster-production


### PR DESCRIPTION
update regolith stack name from `ala-regolith-cluster-testing-testing` to `ala-regolith-cluster-testing` To match the updated stack here https://github.com/AtlasOfLivingAustralia/ala-regolith/pull/19