### PR TITLE
Add option to enable or disable cloudwatch logs exports

### DIFF
--- a/cicd/database/app/database.yaml
+++ b/cicd/database/app/database.yaml
@@ -56,6 +56,12 @@ Parameters:
       - staging
       - production
     Type: String
+  pExportLogs:
+    Description: Enable or disable exporting logs to CloudWatch
+    Type: String
+    AllowedValues:
+      - true
+      - false
   pInstanceClass:
     Description: The RDS instance class
     Type: String
@@ -96,6 +102,9 @@ Conditions:
   CreateReplica: !Equals
                     - !Ref pCreateReplica
                     - true
+  ExportLogs: !Equals
+                - !Ref pExportLogs
+                - true
   EnhancedMonitoring: !Not 
                         - !Equals
                           - !Ref pEnhancedMonitoring
@@ -194,9 +203,7 @@ Resources:
       DBClusterParameterGroupName: !Ref ClusterParamGrp
       DBSubnetGroupName: !Ref DbSubnetGrp
       DeletionProtection: !Ref pDeletionProtection
-      EnableCloudwatchLogsExports:
-        - error
-        - slowquery
+      EnableCloudwatchLogsExports: !If [ ExportLogs, ['error', 'slowquery'], !Ref AWS::NoValue]
       Engine: aurora-mysql
       EngineMode: !If [IsServerlessV2, !Ref AWS::NoValue, provisioned]
       EngineVersion: !Ref pDbVersion

--- a/cicd/database/app/database.yaml
+++ b/cicd/database/app/database.yaml
@@ -44,6 +44,10 @@ Parameters:
       - provisioned
       - serverlessv2
     Default: provisioned
+  pEnhancedMonitoring:
+    Description: enhanced monitoring interval in seconds, 0 to disable
+    Type: Number
+    Default: 0
   pEnvironment:
     Description: Environment for this RDS instance
     AllowedValues:
@@ -80,9 +84,9 @@ Conditions:
             - !Ref pEnvironment
             - production
   RestoreFromSnapshot: !Not
-                          - !Equals
-                              - !Ref pRdsSnapshotRestore
-                              - false
+                         - !Equals
+                           - !Ref pRdsSnapshotRestore
+                           - false
   IsProvisioned: !Equals 
                    - !Ref pEngineMode
                    - provisioned
@@ -92,13 +96,17 @@ Conditions:
   CreateReplica: !Equals
                     - !Ref pCreateReplica
                     - true
+  EnhancedMonitoring: !Not 
+                        - !Equals
+                          - !Ref pEnhancedMonitoring
+                          - 0
   HorizontalScaling: !And
                       - !Equals
-                          - !Ref pEngineMode
-                          - provisioned
+                        - !Ref pEngineMode
+                        - provisioned
                       - !Equals
-                          - !Ref pCreateReplica
-                          - true
+                        - !Ref pCreateReplica
+                        - true
 
 
 Resources:
@@ -196,8 +204,11 @@ Resources:
       MasterUserPassword: !Sub
                             - '{{resolve:secretsmanager:alerts-${ResourceName}:SecretString:db-password}}'
                             - ResourceName: !If [ IsDev, !Ref pCleanBranch, !Ref pEnvironment ]
-      MonitoringInterval: 60
-      MonitoringRoleArn: !GetAtt EnhancedMonitoringRole.Arn
+      MonitoringInterval: !Ref pEnhancedMonitoring
+      MonitoringRoleArn: !If
+                           - EnhancedMonitoring
+                           - !GetAtt EnhancedMonitoringRole.Arn
+                           - !Ref AWS::NoValue
       PerformanceInsightsEnabled: !Ref pPerformanceInsights
       Port: 3306
       PreferredBackupWindow: 16:00-17:00

--- a/cicd/database/app/database_template_config.j2
+++ b/cicd/database/app/database_template_config.j2
@@ -12,6 +12,7 @@
     "pEngineMode"          : "{{ engine_mode }}",
     "pEnhancedMonitoring"  : "{{ enhanced_monitoring }}",
     "pEnvironment"         : "{{ environment }}",
+    "pExportLogs"          : "{{ export_logs }}",
     "pInstanceClass"       : "{{ instance_class }}",
     "pPerformanceInsights" : "{{ performance_insights }}",
     "pProductName"         : "{{ product_name }}",

--- a/cicd/database/app/database_template_config.j2
+++ b/cicd/database/app/database_template_config.j2
@@ -10,6 +10,7 @@
     "pDbVersion"           : "{{ db_version }}",
     "pDeletionProtection"  : "{{ deletion_protection }}",
     "pEngineMode"          : "{{ engine_mode }}",
+    "pEnhancedMonitoring"  : "{{ enhanced_monitoring }}",
     "pEnvironment"         : "{{ environment }}",
     "pInstanceClass"       : "{{ instance_class }}",
     "pPerformanceInsights" : "{{ performance_insights }}",

--- a/cicd/database/config.ini
+++ b/cicd/database/config.ini
@@ -22,6 +22,7 @@ PERFORMANCE_INSIGHTS = false
 ENHANCED_MONITORING = 0
 # The snapshot ARN to restore the database from. Set to "false" to not use a snapshot.
 RDS_SNAPSHOT_RESTORE = false
+EXPORT_LOGS = false
 
 
 [development]

--- a/cicd/database/config.ini
+++ b/cicd/database/config.ini
@@ -11,13 +11,15 @@ SLACK_ALERT_CHANNEL = deployments
 ADMIN_USER = admin
 BACKTRACK_WINDOW = 86400
 BACKUP_RETENTION = 1
-CREATE_REPLICA = true
+CREATE_REPLICA = false
 DB_INSTANCE_NAME = alerts-${ENVIRONMENT}
 DB_VERSION = 8.0.mysql_aurora.3.08.0
 DELETION_PROTECTION = false
 ENGINE_MODE = serverlessv2
 INSTANCE_CLASS = db.t4g.medium
 PERFORMANCE_INSIGHTS = false
+# enhanced monitoring interval in seconds. Set to 0 to disable.
+ENHANCED_MONITORING = 0
 # The snapshot ARN to restore the database from. Set to "false" to not use a snapshot.
 RDS_SNAPSHOT_RESTORE = false
 
@@ -37,7 +39,6 @@ DB_INSTANCE_NAME = alerts-${CLEAN_BRANCH}
 [testing]
 AUTO_DEPLOY = true
 # RDS
-PERFORMANCE_INSIGHTS = true
 
 [staging]
 # RDS
@@ -47,4 +48,6 @@ PERFORMANCE_INSIGHTS = true
 # RDS
 DELETION_PROTECTION = true
 PERFORMANCE_INSIGHTS = true
+ENHANCED_MONITORING = 60
 BACKUP_RETENTION = 14
+CREATE_REPLICA = true


### PR DESCRIPTION
Cloudwatch log exports were preventing the serverless DB to scale to zero 