### PR TITLE
Feature/this is a long branch name to test teardown

### DIFF
--- a/cicd/clean_branch.sh
+++ b/cicd/clean_branch.sh
@@ -9,4 +9,4 @@
 
 SRC_BRANCH=$1
 
-echo $SRC_BRANCH | sed 's/^feature\///' | sed 's/[/_]/-/g' | sed 's/[^a-zA-Z0-9-]//g' | tr '[:upper:]' '[:lower:]' | cut -c 1-30 | sed -E 's/[^a-z0-9]+$//'
+echo -n $SRC_BRANCH | sed 's/^feature\///' | sed 's/[/_]/-/g' | sed 's/[^a-zA-Z0-9-]//g' | tr '[:upper:]' '[:lower:]' | cut -c 1-30 | sed -E 's/[^a-z0-9]+$//'

--- a/cicd/clean_branch.sh
+++ b/cicd/clean_branch.sh
@@ -9,4 +9,4 @@
 
 SRC_BRANCH=$1
 
-echo $SRC_BRANCH | sed 's/^feature\///' | sed 's/[/_]/-/g' | sed 's/[^a-zA-Z0-9-]//g' | tr '[:upper:]' '[:lower:]' | cut -c 1-30 | sed 's/[^a-z0-9]\+$//'
+echo $SRC_BRANCH | sed 's/^feature\///' | sed 's/[/_]/-/g' | sed 's/[^a-zA-Z0-9-]//g' | tr '[:upper:]' '[:lower:]' | cut -c 1-30 | sed -E 's/[^a-z0-9]\+$//'

--- a/cicd/clean_branch.sh
+++ b/cicd/clean_branch.sh
@@ -3,8 +3,10 @@
 ###
 # Sanitise a git branch name so that it can be used in AWS resource and stack names
 #
-# e.g. feature/Create_new_logo! will be changed to feature-create-new-logo
+# e.g. feature/Create_new_logo! will be changed to create-new-logo
+#
+# some resource names can only end in letters or numbers so we remove any trailing non-alphanumeric characters
 
 SRC_BRANCH=$1
 
-echo $SRC_BRANCH | sed 's/[/_]/-/g' | sed 's/[^a-zA-Z0-9-]//g' | tr '[:upper:]' '[:lower:]' | cut -c 1-30
+echo $SRC_BRANCH | sed 's/^feature\///' | sed 's/[/_]/-/g' | sed 's/[^a-zA-Z0-9-]//g' | tr '[:upper:]' '[:lower:]' | cut -c 1-30 | sed 's/[^a-z0-9]\+$//'

--- a/cicd/clean_branch.sh
+++ b/cicd/clean_branch.sh
@@ -9,4 +9,4 @@
 
 SRC_BRANCH=$1
 
-echo $SRC_BRANCH | sed 's/^feature\///' | sed 's/[/_]/-/g' | sed 's/[^a-zA-Z0-9-]//g' | tr '[:upper:]' '[:lower:]' | cut -c 1-30 | sed -E 's/[^a-z0-9]\+$//'
+echo $SRC_BRANCH | sed 's/^feature\///' | sed 's/[/_]/-/g' | sed 's/[^a-zA-Z0-9-]//g' | tr '[:upper:]' '[:lower:]' | cut -c 1-30 | sed -E 's/[^a-z0-9]+$//'


### PR DESCRIPTION
This branch was an attempt to troubleshoot why a branch was not tearing down the helm application, i thought it might be a mismatch with [the actual application and what it thought it was](https://github.com/AtlasOfLivingAustralia/alerts/blob/develop/cicd/backend/pipeline/teardown_alerts_buildspec.yaml#L25-L29) but that wasnt it. I couldnt even reproduce it in the end. Some one off glitch, will keep a look out if it happens again.


In the process I fixed a bug and made some updates to the script that creates the clean_branch variable

- remove the "feature/" prefix from branch names. not needed and it takes up space.
- remove any trailing non alpha-numerics. In some cases deploys were failing because the clean branch was truncated in a way where it ended in a "-" char, when the clean branch was used for AWS resource names it was failing because they must end in a alpha-numeric char. E.G ECR 
- dont print the newline when echoing the variable 