### PR TITLE
Increase ALB connection idle timeout to 90s

### DIFF
--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -14,7 +14,7 @@ metadata:
     alb.ingress.kubernetes.io/ssl-redirect: '443'
     alb.ingress.kubernetes.io/success-codes: '200'
     alb.ingress.kubernetes.io/healthcheck-path: /actuator/health
-    alb.ingress.kubernetes.io/idle-timeout: '90'
+    alb.ingress.kubernetes.io/load-balancer-attributes: 'idle_timeout.timeout_seconds=90'
     external-dns.alpha.kubernetes.io/hostname: {{ .Values.ingress.hostname }}
     {{- include "ala-alerts.labels" . | nindent 4 }}
 spec:

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -14,6 +14,7 @@ metadata:
     alb.ingress.kubernetes.io/ssl-redirect: '443'
     alb.ingress.kubernetes.io/success-codes: '200'
     alb.ingress.kubernetes.io/healthcheck-path: /actuator/health
+    alb.ingress.kubernetes.io/idle-timeout: '90'
     external-dns.alpha.kubernetes.io/hostname: {{ .Values.ingress.hostname }}
     {{- include "ala-alerts.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
Increasing connection idle timeout to 90s.
I did have a look at adding per-path timeout configuration. The aws load balancer controller does not support per-path timeout configuration on an ALB. The idle timeout is a global setting for the entire ALB and cannot be adjusted for individual paths. It will require an additional load balancer for that specific path. I think we can try increasing this timeout for now.