### PR TITLE
Remove app vars from the pipeline

### DIFF
--- a/cicd/backend/pipeline/deploy_pipeline.sh
+++ b/cicd/backend/pipeline/deploy_pipeline.sh
@@ -149,7 +149,5 @@ aws cloudformation deploy \
         pPipelineFingerprint=$PIPELINE_MD5 \
         pProductComponent=$PRODUCT_COMPONENT \
         pProductName=$PRODUCT_NAME \
-        pDomainName=$DOMAIN_NAME \
-        pSecretName=$SECRET_NAME \
         pRestartExecutionOnUpdate=$RESTART_PIPELINE_ON_UPDATE \
 

--- a/cicd/backend/pipeline/pipeline.yaml
+++ b/cicd/backend/pipeline/pipeline.yaml
@@ -38,12 +38,6 @@ Parameters:
   pProductName:
     Type: String
     Description: The name of the product
-  pDomainName:
-    Type: String
-    Description: The domain name
-  pSecretName:
-    Type: String
-    Description: The name of the secret
   pRestartExecutionOnUpdate:
     Type: String
     Description: Restart that pipeline if it's been updated
@@ -254,7 +248,7 @@ Resources:
                    { "name":"PIPELINE_FINGERPRINT", "value":"#{variables.PIPELINE_FINGERPRINT}" },
                    { "name":"PRODUCT_COMPONENT", "value":"${pProductComponent}" },
                    { "name":"SRC_BRANCH", "value":"${pGitHubBranch}" },
-                   { "name":"SECRET_NAME", "value":"${pSecretName}" }
+                   { "name":"SECRET_NAME", "value":"#{ExportConfigNS.SECRET_NAME}" }
                  ]
             Namespace: ExportConfigNS
             InputArtifacts:


### PR DESCRIPTION
Keeping applications variables out of the pipeline reduces the need to relaunch the pipeline.

When just the pipeline parameters change then it doesnt automatically get relaunched leading to errors, I was planning on including the pipeline parameter values in the MD5 so it could detect changes but even that is imperfect as the checkout source actions run before the change detection in the export_config action so repo changes would be missed.

