### PR TITLE
Enforce s3 SSL

### DIFF
--- a/cicd/base/app/base.yaml
+++ b/cicd/base/app/base.yaml
@@ -175,7 +175,7 @@ Resources:
               - !Sub "arn:aws:s3:::${LoadBalancerAccessLogsBucket}/*"
             Condition:
               Bool:
-                aws:SecureTransport: false
+                aws:SecureTransport: 'false'
 
   BiosecurityAlertsBucketPolicy:
     Type: AWS::S3::BucketPolicy
@@ -193,7 +193,7 @@ Resources:
               - !Sub "arn:aws:s3:::${BiosecurityAlertsBucket}/*"
             Condition:
               Bool:
-                aws:SecureTransport: false
+                aws:SecureTransport: 'false'
 
   AlertsRole:
     Type: AWS::IAM::Role

--- a/cicd/base/app/base.yaml
+++ b/cicd/base/app/base.yaml
@@ -166,6 +166,34 @@ Resources:
               Service: "logdelivery.elasticloadbalancing.amazonaws.com"
             Action: "s3:PutObject"
             Resource: !Sub "arn:aws:s3:::${LoadBalancerAccessLogsBucket}/logs/AWSLogs/${AWS::AccountId}/*"
+          - Sid: EnforceSSLOnly
+            Effect: Deny
+            Principal: '*'
+            Action: 's3:*'
+            Resource:
+              - !Sub "arn:aws:s3:::${LoadBalancerAccessLogsBucket}"
+              - !Sub "arn:aws:s3:::${LoadBalancerAccessLogsBucket}/*"
+            Condition:
+              Bool:
+                aws:SecureTransport: false
+
+  BiosecurityAlertsBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref BiosecurityAlertsBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: EnforceSSLOnly
+            Effect: Deny
+            Principal: '*'
+            Action: 's3:*'
+            Resource:
+              - !Sub "arn:aws:s3:::${BiosecurityAlertsBucket}"
+              - !Sub "arn:aws:s3:::${BiosecurityAlertsBucket}/*"
+            Condition:
+              Bool:
+                aws:SecureTransport: false
 
   AlertsRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
add S3 bucket policies to enforce SSL connections for LoadBalancerAccessLogsBucket and BiosecurityAlertsBucket.

IM&T has started sending us remediation emails every time this is not applied 