### PR TITLE
Feature/elb tags

### DIFF
--- a/cicd/backend/pipeline/deploy_alerts_buildspec.yaml
+++ b/cicd/backend/pipeline/deploy_alerts_buildspec.yaml
@@ -37,6 +37,17 @@ phases:
       - cd helm
       - export BUILD_TAG_FROM_ARTIFACT=$(cat "$CODEBUILD_SRC_DIR_BuildTagArtifact/build_tag.txt")
       - |
+        echo helm upgrade --install $HELM_RELEASE_NAME . -n $EKS_NAMESPACE \
+          --set image.repository=$ECR_REPO \
+          --set image.tag=$BUILD_TAG_FROM_ARTIFACT \
+          --set ingress.hostname=$DOMAIN_NAME \
+          --set rds.externalName=$DB_WRITE_ENDPOINT \
+          --set ingress.certificateArn=$CERTIFICATE_ARN \
+          --set secret.name=alerts-config-secret-$CLEAN_BRANCH \
+          --set serviceAccount.name=alerts-service-account-$CLEAN_BRANCH \
+          --set rds.name=mysql-rds-$CLEAN_BRANCH \
+          -f $CODEBUILD_SRC_DIR_ExportConfigArtifact/helm-values.yaml
+      - |
         helm upgrade --install $HELM_RELEASE_NAME . -n $EKS_NAMESPACE \
           --set image.repository=$ECR_REPO \
           --set image.tag=$BUILD_TAG_FROM_ARTIFACT \

--- a/cicd/backend/pipeline/deploy_alerts_buildspec.yaml
+++ b/cicd/backend/pipeline/deploy_alerts_buildspec.yaml
@@ -37,17 +37,6 @@ phases:
       - cd helm
       - export BUILD_TAG_FROM_ARTIFACT=$(cat "$CODEBUILD_SRC_DIR_BuildTagArtifact/build_tag.txt")
       - |
-        echo helm upgrade --install $HELM_RELEASE_NAME . -n $EKS_NAMESPACE \
-          --set image.repository=$ECR_REPO \
-          --set image.tag=$BUILD_TAG_FROM_ARTIFACT \
-          --set ingress.hostname=$DOMAIN_NAME \
-          --set rds.externalName=$DB_WRITE_ENDPOINT \
-          --set ingress.certificateArn=$CERTIFICATE_ARN \
-          --set secret.name=alerts-config-secret-$CLEAN_BRANCH \
-          --set serviceAccount.name=alerts-service-account-$CLEAN_BRANCH \
-          --set rds.name=mysql-rds-$CLEAN_BRANCH \
-          -f $CODEBUILD_SRC_DIR_ExportConfigArtifact/helm-values.yaml
-      - |
         helm upgrade --install $HELM_RELEASE_NAME . -n $EKS_NAMESPACE \
           --set image.repository=$ECR_REPO \
           --set image.tag=$BUILD_TAG_FROM_ARTIFACT \

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -60,3 +60,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Comma-separated key=value tag string built from .Values.tags, e.g. "product=alerts,branch=main"
+*/}}
+{{- define "ala-alerts.resourceTags" -}}
+{{- $tags := list }}
+{{- range $key, $value := .Values.tags }}
+{{- $tags = append $tags (printf "%s=%s" $key $value) }}
+{{- end }}
+{{- join "," $tags }}
+{{- end }}

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -15,12 +15,7 @@ metadata:
     alb.ingress.kubernetes.io/success-codes: '200'
     alb.ingress.kubernetes.io/healthcheck-path: /actuator/health
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-Res-PQ-2025-09
-    alb.ingress.kubernetes.io/tags: >
-      {{- $tags := list }}
-      {{- range $key, $value := .Values.tags }}
-      {{- $tags = append $tags (printf "%s=%s" $key $value) }}
-      {{- end }}
-      alb.ingress.kubernetes.io/tags: {{ join "," $tags }}
+    alb.ingress.kubernetes.io/tags: {{ include "ala-alerts.resourceTags" . | quote }}
     alb.ingress.kubernetes.io/load-balancer-attributes: >
       idle_timeout.timeout_seconds=600,
       access_logs.s3.enabled=true,

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: {{ include "ala-alerts.resourceTags" . | quote }}
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort}}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -4,6 +4,8 @@ metadata:
   name: svc-{{ include "ala-alerts.fullname" . }}
   labels:
     {{- include "ala-alerts.labels" . | nindent 4 }}
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: {{ include "ala-alerts.resourceTags" . | quote }}
 spec:
   type: LoadBalancer
   ports:


### PR DESCRIPTION
Refactors Load balancer tagging, setting service type to clusterIP means the Network LB doesnt launch. We dont need it, it just costs money